### PR TITLE
feat: Add Apollo provider hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,15 @@ quasar ext remove @quasar/apollo
 
 Apollo client can be configured through `src/quasar-app-extension-apollo/apollo-client-config.js`.
 
-For advanced configuration needs, the extension provides two hooks, one gets called before the apollo client instantiation and the other afterwards. The hooks are `apolloClientBeforeCreate` and `apolloClientAfterCreate`, and can be modified as needed in `src/quasar-app-extension-apollo/apollo-client-hooks.js`.
+## Advanced configuration
+
+### Apollo client
+
+The extension provides two hooks, one gets called before the apollo client instantiation and the other afterwards. The hooks are `apolloClientBeforeCreate` and `apolloClientAfterCreate`, and can be modified as needed in `src/quasar-app-extension-apollo/apollo-client-hooks.js`.
+
+### Apollo provider
+
+The extension provides two hooks, one gets called before the apollo provider instantiation and the other afterwards. The hooks are `apolloProviderBeforeCreate` and `apolloProviderAfterCreate`, and can be modified as needed in `src/quasar-app-extension-apollo/apollo-provider-hooks.js`.
 
 ## Usage
 

--- a/src/boot/apollo-ssr.js
+++ b/src/boot/apollo-ssr.js
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import VueApollo from 'vue-apollo'
 import ApolloSSR from 'vue-apollo/ssr'
 import createApolloClient from '../graphql/create-apollo-client-ssr'
+import { apolloProviderBeforeCreate, apolloProviderAfterCreate } from 'src/quasar-app-extension-apollo/apollo-provider-hooks'
 
 // Install the vue plugin
 Vue.use(VueApollo)
@@ -10,8 +11,16 @@ export default ({ app, router, store, ssrContext, urlPath, redirect }) => {
   // create an 'apollo client' instance
   const apolloClient = createApolloClient({ app, router, store, ssrContext, urlPath, redirect })
 
+  const apolloProviderConfigObj = { defaultClient: apolloClient }
+
+  // run hook before creating apollo provider instance
+  apolloProviderBeforeCreate({ apolloProviderConfigObj, app, router, store, ssrContext, urlPath, redirect })
+
   // create an 'apollo provider' instance
-  const apolloProvider = new VueApollo({ defaultClient: apolloClient })
+  const apolloProvider = new VueApollo(apolloProviderConfigObj)
+
+  // run hook after creating apollo provider instance
+  apolloProviderAfterCreate({ apolloProvider, app, router, store, ssrContext, urlPath, redirect })
 
   // attach created 'apollo provider' instance to the app
   app.apolloProvider = apolloProvider

--- a/src/boot/apollo.js
+++ b/src/boot/apollo.js
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import VueApollo from 'vue-apollo'
 import createApolloClient from '../graphql/create-apollo-client'
+import { apolloProviderBeforeCreate, apolloProviderAfterCreate } from 'src/quasar-app-extension-apollo/apollo-provider-hooks'
 
 // Install vue-apollo plugin
 Vue.use(VueApollo)
@@ -9,8 +10,16 @@ export default ({ app, router, store, urlPath, redirect }) => {
   // create an 'apollo client' instance
   const apolloClient = createApolloClient({ app, router, store, urlPath, redirect })
 
+  const apolloProviderConfigObj = { defaultClient: apolloClient }
+
+  // run hook before creating apollo provider instance
+  apolloProviderBeforeCreate({ apolloProviderConfigObj, app, router, store, urlPath, redirect })
+
   // create an 'apollo provider' instance
-  const apolloProvider = new VueApollo({ defaultClient: apolloClient })
+  const apolloProvider = new VueApollo(apolloProviderConfigObj)
+
+  // run hook after creating apollo provider instance
+  apolloProviderAfterCreate({ apolloProvider, app, router, store, urlPath, redirect })
 
   // attach created 'apollo provider' instance to the app
   app.apolloProvider = apolloProvider

--- a/src/templates/src/quasar-app-extension-apollo/apollo-provider-hooks.js
+++ b/src/templates/src/quasar-app-extension-apollo/apollo-provider-hooks.js
@@ -1,0 +1,8 @@
+export function apolloProviderBeforeCreate (/* { apolloProviderConfigObj, app, router, store, ssrContext, urlPath, redirect } */) {
+  // if needed you can modify here the config object used for apollo provider
+  // instantiation
+}
+
+export function apolloProviderAfterCreate (/* { apolloProvider, app, router, store, ssrContext, urlPath, redirect } */) {
+  // if needed you can modify here the created apollo provider
+}


### PR DESCRIPTION
Add Apollo provider hooks to allow full control and advanced usage.

An example would be creating multiple Apollo clients.

Testing needed.

closes #40 