### PR TITLE
Create exportsV2.js

### DIFF
--- a/src/exportsV2.js
+++ b/src/exportsV2.js
@@ -1,0 +1,11 @@
+// the following will be injected in the app 'index.template.html', it contains
+// the graphql query results run in the server. The client will find them in
+// 'window.__APOLLO_STATE__' and uses them to initialize apollo-client cache,
+// thus removing the need to run the queries again in the client
+// https://ssr.vuejs.org/guide/build-config.html#manual-asset-injection
+module.exports.graphqlHtml = `
+    <% // added by 'quasar-app-extension-apollo' %>
+    <% if (ctx.mode.ssr) { %>
+      {{{ renderState({ contextKey: 'apolloState', windowKey: '__APOLLO_STATE__' }) }}}
+    <% } %>
+  `


### PR DESCRIPTION
Webpack fail to compile html templates in `@quasar/cli` V2.

`htmlWebpackPlugin.options` has to be removed only for V2 of `@quasar/cli`.