### PR TITLE
Make extension functions async

### DIFF
--- a/src/boot/apollo-ssr.js
+++ b/src/boot/apollo-ssr.js
@@ -10,9 +10,9 @@ import {
 // Install the vue plugin
 Vue.use(VueApollo);
 
-export default ({ app, router, store, ssrContext, urlPath, redirect }) => {
+export default async ({ app, router, store, ssrContext, urlPath, redirect }) => {
   // create an 'apollo client' instance
-  const apolloClient = createApolloClient({
+  const apolloClient = await createApolloClient({
     app,
     router,
     store,
@@ -24,7 +24,7 @@ export default ({ app, router, store, ssrContext, urlPath, redirect }) => {
   const apolloProviderConfigObj = { defaultClient: apolloClient };
 
   // run hook before creating apollo provider instance
-  apolloProviderBeforeCreate({
+  await apolloProviderBeforeCreate({
     apolloProviderConfigObj,
     app,
     router,
@@ -38,7 +38,7 @@ export default ({ app, router, store, ssrContext, urlPath, redirect }) => {
   const apolloProvider = new VueApollo(apolloProviderConfigObj);
 
   // run hook after creating apollo provider instance
-  apolloProviderAfterCreate({
+  await apolloProviderAfterCreate({
     apolloProvider,
     app,
     router,

--- a/src/boot/apollo.js
+++ b/src/boot/apollo.js
@@ -9,9 +9,9 @@ import {
 // Install vue-apollo plugin
 Vue.use(VueApollo);
 
-export default ({ app, router, store, urlPath, redirect }) => {
+export default async ({ app, router, store, urlPath, redirect }) => {
   // create an 'apollo client' instance
-  const apolloClient = createApolloClient({
+  const apolloClient = await createApolloClient({
     app,
     router,
     store,
@@ -22,7 +22,7 @@ export default ({ app, router, store, urlPath, redirect }) => {
   const apolloProviderConfigObj = { defaultClient: apolloClient };
 
   // run hook before creating apollo provider instance
-  apolloProviderBeforeCreate({
+   await apolloProviderBeforeCreate({
     apolloProviderConfigObj,
     app,
     router,
@@ -35,7 +35,7 @@ export default ({ app, router, store, urlPath, redirect }) => {
   const apolloProvider = new VueApollo(apolloProviderConfigObj);
 
   // run hook after creating apollo provider instance
-  apolloProviderAfterCreate({
+  await apolloProviderAfterCreate({
     apolloProvider,
     app,
     router,

--- a/src/graphql/create-apollo-client-ssr.js
+++ b/src/graphql/create-apollo-client-ssr.js
@@ -14,7 +14,7 @@ import {
 const onServer = process.env.SERVER;
 
 // function that returns an 'apollo client' instance
-export default function ({
+export default async function ({
   app,
   router,
   store,
@@ -22,7 +22,7 @@ export default function ({
   urlPath,
   redirect
 }) {
-  const cfg = getApolloClientConfig({
+  const cfg = await getApolloClientConfig({
     app,
     router,
     store,
@@ -51,7 +51,7 @@ export default function ({
   const apolloClientConfigObj = { link, cache, ...cfg.additionalConfig };
 
   // run hook before creating apollo client instance
-  apolloClientBeforeCreate({
+  await apolloClientBeforeCreate({
     apolloClientConfigObj,
     app,
     router,
@@ -65,7 +65,7 @@ export default function ({
   const apolloClient = new ApolloClient(apolloClientConfigObj);
 
   // run hook after creating apollo client instance
-  apolloClientAfterCreate({
+  await apolloClientAfterCreate({
     apolloClient,
     app,
     router,

--- a/src/graphql/create-apollo-client.js
+++ b/src/graphql/create-apollo-client.js
@@ -8,8 +8,8 @@ import {
 } from 'src/apollo/apollo-client-hooks';
 
 // function that returns an 'apollo client' instance
-export default function ({ app, router, store, urlPath, redirect }) {
-  const cfg = getApolloClientConfig({ app, router, store, urlPath, redirect });
+export default async function ({ app, router, store, urlPath, redirect }) {
+  const cfg = await getApolloClientConfig({ app, router, store, urlPath, redirect });
 
   // create apollo client link
   const link = new HttpLink(cfg.httpLinkConfig);
@@ -21,7 +21,7 @@ export default function ({ app, router, store, urlPath, redirect }) {
   const apolloClientConfigObj = { link, cache, ...cfg.additionalConfig };
 
   // run hook before creating apollo client instance
-  apolloClientBeforeCreate({
+  await apolloClientBeforeCreate({
     apolloClientConfigObj,
     app,
     router,
@@ -34,7 +34,7 @@ export default function ({ app, router, store, urlPath, redirect }) {
   const apolloClient = new ApolloClient(apolloClientConfigObj);
 
   // run hook after creating apollo client instance
-  apolloClientAfterCreate({
+  await apolloClientAfterCreate({
     apolloClient,
     app,
     router,

--- a/src/graphql/get-apollo-client-config.js
+++ b/src/graphql/get-apollo-client-config.js
@@ -9,7 +9,7 @@ const quasarMode = process.env.MODE;
 // https://quasar.dev/quasar-cli/cli-documentation/handling-process-env#Values-supplied-by-Quasar-CLI
 const onServer = process.env.SERVER;
 
-export default function ({
+export default async function ({
   app,
   router,
   store,
@@ -18,7 +18,7 @@ export default function ({
   redirect
 }) {
   // get raw configuration provided by the app
-  const rawConfig = config({
+  const rawConfig = await config({
     app,
     router,
     store,

--- a/src/templates/src/apollo/apollo-client-config.js
+++ b/src/templates/src/apollo/apollo-client-config.js
@@ -1,4 +1,4 @@
-export default function (/* { app, router, store, ssrContext, urlPath, redirect } */) {
+export default async function (/* { app, router, store, ssrContext, urlPath, redirect } */) {
   return {
     default: {
       // 'apollo-link-http' config

--- a/src/templates/src/apollo/apollo-client-hooks.js
+++ b/src/templates/src/apollo/apollo-client-hooks.js
@@ -1,8 +1,8 @@
-export function apolloClientBeforeCreate (/* { apolloClientConfigObj, app, router, store, ssrContext, urlPath, redirect } */) {
+export async function apolloClientBeforeCreate (/* { apolloClientConfigObj, app, router, store, ssrContext, urlPath, redirect } */) {
   // if needed you can modify here the config object used for apollo client
   // instantiation
 }
 
-export function apolloClientAfterCreate (/* { apolloClient, app, router, store, ssrContext, urlPath, redirect } */) {
+export async function apolloClientAfterCreate (/* { apolloClient, app, router, store, ssrContext, urlPath, redirect } */) {
   // if needed you can modify here the created apollo client
 }

--- a/src/templates/src/apollo/apollo-provider-hooks.js
+++ b/src/templates/src/apollo/apollo-provider-hooks.js
@@ -1,8 +1,8 @@
-export function apolloProviderBeforeCreate (/* { apolloProviderConfigObj, app, router, store, ssrContext, urlPath, redirect } */) {
+export async function apolloProviderBeforeCreate (/* { apolloProviderConfigObj, app, router, store, ssrContext, urlPath, redirect } */) {
   // if needed you can modify here the config object used for apollo provider
   // instantiation
 }
 
-export function apolloProviderAfterCreate (/* { apolloProvider, app, router, store, ssrContext, urlPath, redirect } */) {
+export async function apolloProviderAfterCreate (/* { apolloProvider, app, router, store, ssrContext, urlPath, redirect } */) {
   // if needed you can modify here the created apollo provider
 }


### PR DESCRIPTION
Make extension functions async to allow users to add async calls in their configs, for example loading external resources, dynamic imports...etc.

This PR does not cause any breaking changes, other than the need for users to add the word `async` to the functions of their previous configs when they want to use `await` inside them.

Please test.