### PR TITLE
Add cfg param to apollo client creation functions.

### DIFF
--- a/src/boot/apollo-ssr.js
+++ b/src/boot/apollo-ssr.js
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import VueApollo from 'vue-apollo';
 import ApolloSSR from 'vue-apollo/ssr';
+import getApolloClientConfig from '../graphql/get-apollo-client-config';
 import createApolloClient from '../graphql/create-apollo-client-ssr';
 import {
   apolloProviderBeforeCreate,
@@ -11,8 +12,18 @@ import {
 Vue.use(VueApollo);
 
 export default ({ app, router, store, ssrContext, urlPath, redirect }) => {
+ const cfg = getApolloClientConfig({
+    app,
+    router,
+    store,
+    ssrContext,
+    urlPath,
+    redirect
+  });
+
   // create an 'apollo client' instance
   const apolloClient = createApolloClient({
+    cfg,
     app,
     router,
     store,

--- a/src/boot/apollo.js
+++ b/src/boot/apollo.js
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 import VueApollo from 'vue-apollo';
+import getApolloClientConfig from '../graphql/get-apollo-client-config';
 import createApolloClient from '../graphql/create-apollo-client';
 import {
   apolloProviderBeforeCreate,
@@ -10,8 +11,11 @@ import {
 Vue.use(VueApollo);
 
 export default ({ app, router, store, urlPath, redirect }) => {
+  const cfg = getApolloClientConfig({ app, router, store, urlPath, redirect });
+
   // create an 'apollo client' instance
   const apolloClient = createApolloClient({
+    cfg,
     app,
     router,
     store,

--- a/src/graphql/create-apollo-client-ssr.js
+++ b/src/graphql/create-apollo-client-ssr.js
@@ -2,7 +2,6 @@ import { ApolloClient } from 'apollo-client';
 import { HttpLink } from 'apollo-link-http';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import fetch from 'node-fetch';
-import getApolloClientConfig from './get-apollo-client-config';
 import {
   apolloClientBeforeCreate,
   apolloClientAfterCreate
@@ -15,6 +14,7 @@ const onServer = process.env.SERVER;
 
 // function that returns an 'apollo client' instance
 export default function ({
+  cfg,
   app,
   router,
   store,
@@ -22,15 +22,6 @@ export default function ({
   urlPath,
   redirect
 }) {
-  const cfg = getApolloClientConfig({
-    app,
-    router,
-    store,
-    ssrContext,
-    urlPath,
-    redirect
-  });
-
   // when on server, we use 'node-fetch' polyfill
   // https://www.apollographql.com/docs/link/links/http/#fetch-polyfill
   if (onServer) {

--- a/src/graphql/create-apollo-client.js
+++ b/src/graphql/create-apollo-client.js
@@ -1,16 +1,13 @@
 import { ApolloClient } from 'apollo-client';
 import { HttpLink } from 'apollo-link-http';
 import { InMemoryCache } from 'apollo-cache-inmemory';
-import getApolloClientConfig from './get-apollo-client-config';
 import {
   apolloClientBeforeCreate,
   apolloClientAfterCreate
 } from 'src/apollo/apollo-client-hooks';
 
 // function that returns an 'apollo client' instance
-export default function ({ app, router, store, urlPath, redirect }) {
-  const cfg = getApolloClientConfig({ app, router, store, urlPath, redirect });
-
+export default function ({ cfg, app, router, store, urlPath, redirect }) {
   // create apollo client link
   const link = new HttpLink(cfg.httpLinkConfig);
 


### PR DESCRIPTION
Allow the apollo client creation functions to take a configuration parameter. This will make it is easier for the extension users to instantiate different clients with varying configs.
See https://github.com/quasarframework/app-extension-apollo/issues/84

Note: This PR will have merge conflicts with PR https://github.com/quasarframework/app-extension-apollo/issues/84
When either of the PRs is merged, I will resolve the conflicts on the other.