### PR TITLE
feat: add basic tooling setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,10 @@ The following is an example using `clientA` instead of the default client:
     `, null, { clientId: 'clientA' })
     ...
 ```
+
+## Tooling
+
+An `apollo.config.js` configuration file for [Apollo GraphQL VSCode extension](https://www.apollographql.com/docs/devtools/editor-plugins/) ((`apollographql.vscode-apollo`)) will be automatically scaffolded.
+
+You should fill in the `client.server.url` property with the URL of the server exposing your GraphQL schema.
+This extension will automatically connect to your remote server, read your GraphQL schema and provide autocomplete/schema errors detection for your GraphQL queries.

--- a/README.md
+++ b/README.md
@@ -119,5 +119,6 @@ The following is an example using `clientA` instead of the default client:
 
 An `apollo.config.js` configuration file for [Apollo GraphQL VSCode extension](https://www.apollographql.com/docs/devtools/editor-plugins/) ((`apollographql.vscode-apollo`)) will be automatically scaffolded.
 
-You should fill in the `client.server.url` property with the URL of the server exposing your GraphQL schema.
+You should fill in the `client.sevice.url` property with the URL of the server exposing your GraphQL schema, check [`client.service` documentation](https://www.apollographql.com/docs/devtools/apollo-config/#clientservice) to learn about other options.
+
 This extension will automatically connect to your remote server, read your GraphQL schema and provide autocomplete/schema errors detection for your GraphQL queries.

--- a/lib/templates/apollo.config.js
+++ b/lib/templates/apollo.config.js
@@ -1,0 +1,14 @@
+'use strict'
+/* eslint-env node */
+// See https://www.apollographql.com/docs/devtools/apollo-config/
+module.exports = {
+  client: {
+    service: {
+      name: 'my-service',
+      // URL to the GraphQL API
+      url: 'http://localhost:3000/graphql',
+    },
+    // Files processed by the extension
+    includes: ['src/**/*.vue', 'src/**/*.js', 'src/**/*.ts'],
+  },
+}

--- a/lib/templates/apollo.config.js
+++ b/lib/templates/apollo.config.js
@@ -5,7 +5,6 @@ module.exports = {
   client: {
     service: {
       name: 'my-service',
-      // URL to the GraphQL API
       url: 'http://localhost:3000/graphql',
     },
     // Files processed by the extension

--- a/src/install.js
+++ b/src/install.js
@@ -10,4 +10,8 @@ module.exports = function (api) {
   } else {
     api.render('../lib/templates')
   }
+
+  api.extendJsonFile('.vscode/extensions.json', {
+    recommendations: ['apollographql.vscode-apollo'],
+  })
 }

--- a/src/templates/apollo.config.js
+++ b/src/templates/apollo.config.js
@@ -1,0 +1,13 @@
+/* eslint-env node */
+// See https://www.apollographql.com/docs/devtools/apollo-config/
+module.exports = {
+  client: {
+    service: {
+      name: 'my-service',
+      // URL to the GraphQL API
+      url: 'http://localhost:3000/graphql',
+    },
+    // Files processed by the extension
+    includes: ['src/**/*.vue', 'src/**/*.js', 'src/**/*.ts'],
+  },
+}

--- a/src/templates/apollo.config.js
+++ b/src/templates/apollo.config.js
@@ -4,7 +4,6 @@ module.exports = {
   client: {
     service: {
       name: 'my-service',
-      // URL to the GraphQL API
       url: 'http://localhost:3000/graphql',
     },
     // Files processed by the extension


### PR DESCRIPTION
As it's already done for testing AE and the starter kit, I assumed the user to be using VSCode, as that's the dominant IDE for JS right now.
If the user is using something else, it's quite easy to just delete those files.
It could also be done by prompting a dedicated question, but the fact that we already went full speed on VSCode elsewhere in the ecosystem without negative feedback is probably a strong enough point to keep that assumption here too