### PR TITLE
feat: bump and externalize deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Example usage:
 
 <script setup lang="ts">
 import { useQuery } from '@vue/apollo-composable'
-import gql from 'graphql-tag'
+import { gql } from '@apollo/client/core'
 
 const { result, loading, error } = useQuery(gql`
   query getPosts {

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ This AE uses [Apollo Client](https://www.apollographql.com) and [Vue Apollo](htt
 quasar ext add @quasar/apollo
 ```
 
-**NOTE:** As of 2.1.0-beta.1, version 2 is now in the dev and default branch of the repository. It is also the version you'll get with the "normal" `@quasar/apollo` package. No need to use `@next` anymore.
+**NOTE:** As of 2.1.0-beta.1, version 2 is now in the dev and default branch of the repository. It is also the version you'll get with the "normal" `@quasar/apollo` package. No need to use `@next` tag anymore.
+
+> Since 2.1.0-beta.2 we externalized all deps for this AE: `graphql`, `graphql-tag`, `@apollo/client` and `@vue/apollo-composable`. If you installed a previous version, rerun `quasar ext add @quasar/apollo` command to have compatible deps added to your project `package.json`.
 
 Version 1 has been deprecated and is no longer supported. If you wish to use it, you can install it with `@quasar/apollo@1.0.0-beta.8`.
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-lodash-template": "^0.21.0",
     "graphql": "^16.8.1",
-    "graphql-tag": "^2.12.6",
     "graphql-sse": "^2.3.0",
     "graphql-ws": "^5.14.0",
     "prettier": "^3.0.3",
@@ -55,16 +54,12 @@
     "@vue/apollo-composable": "^4.0.0-alpha.12",
     "graphql": "^15.0.0 || ^16.0.0",
     "graphql-sse": "^2.3.0",
-    "graphql-tag": "^2.12.6",
     "graphql-ws": "^5.14.0",
     "quasar": "^2.0.0",
     "vue": "^3.0.0"
   },
   "peerDependenciesMeta": {
     "graphql-ws": {
-      "optional": true
-    },
-    "graphql-tag": {
       "optional": true
     },
     "graphql-sse": {

--- a/package.json
+++ b/package.json
@@ -33,12 +33,16 @@
     "/lib"
   ],
   "devDependencies": {
+    "@apollo/client": "^3.8.6",
     "@quasar/app-vite": "^1.6.2",
     "@typescript-eslint/eslint-plugin": "^6.7.0",
     "@typescript-eslint/parser": "^6.7.0",
+    "@vue/apollo-composable": "^4.0.0-beta.11",
     "eslint": "^8.49.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-lodash-template": "^0.21.0",
+    "graphql": "^16.8.1",
+    "graphql-tag": "^2.12.6",
     "graphql-sse": "^2.3.0",
     "graphql-ws": "^5.14.0",
     "prettier": "^3.0.3",
@@ -46,20 +50,21 @@
     "typescript": "^5.2.2",
     "vue": "^3.3.4"
   },
-  "dependencies": {
-    "@apollo/client": "^3.8.3",
-    "@vue/apollo-composable": "^4.0.0-alpha.12",
-    "graphql": "^15.5.0",
-    "graphql-tag": "^2.12.4"
-  },
   "peerDependencies": {
-    "quasar": "^2.0.0",
-    "vue": "^3.0.0",
+    "@apollo/client": "^3.0.0",
+    "@vue/apollo-composable": "^4.0.0-alpha.12",
+    "graphql": "^15.0.0 || ^16.0.0",
     "graphql-sse": "^2.3.0",
-    "graphql-ws": "^5.14.0"
+    "graphql-tag": "^2.12.6",
+    "graphql-ws": "^5.14.0",
+    "quasar": "^2.0.0",
+    "vue": "^3.0.0"
   },
   "peerDependenciesMeta": {
     "graphql-ws": {
+      "optional": true
+    },
+    "graphql-tag": {
       "optional": true
     },
     "graphql-sse": {

--- a/src/install.js
+++ b/src/install.js
@@ -85,12 +85,6 @@ module.exports = function (api) {
     subscriptionsTransport,
   })
 
-  if (api.prompts.gqlTag) {
-    extendPackageJson = __mergeDeep(extendPackageJson, {
-      dependencies: getCompatibleDevDependencies(['graphql-tag']),
-    })
-  }
-
   if (subscriptionsTransport === 'ws') {
     extendPackageJson = __mergeDeep(extendPackageJson, {
       dependencies: getCompatibleDevDependencies(['graphql-ws']),

--- a/src/install.js
+++ b/src/install.js
@@ -1,9 +1,41 @@
 /* eslint-env node */
 const { join } = require('path')
 
+// https://github.com/quasarframework/quasar-testing/blob/75e4fb524fd7767492a1cac66fe8169a5b29b6a6/packages/e2e-cypress/src/install.js#L11-L39
+// We need to use this because only the last `api.extendPackageJson` is executed, if multiple calls are made.
+/**
+ * Performs a deep merge of objects and returns new object. Does not modify
+ * objects (immutable) and merges arrays via concatenation.
+ * based on https://stackoverflow.com/a/49798508
+ *
+ * @param {...object} sources - Objects to merge
+ * @returns {object} New object with merged key/values
+ */
+
+function __mergeDeep(...sources) {
+  let result = {}
+  for (const source of sources) {
+    if (source instanceof Array) {
+      if (!(result instanceof Array)) {
+        result = []
+      }
+      result = [...result, ...source]
+    } else if (source instanceof Object) {
+      // eslint-disable-next-line prefer-const
+      for (let [key, value] of Object.entries(source)) {
+        if (value instanceof Object && key in result) {
+          value = __mergeDeep(result[key], value)
+        }
+        result = { ...result, [key]: value }
+      }
+    }
+  }
+  return result
+}
+
 // https://github.com/quasarframework/quasar-testing/blob/75e4fb524fd7767492a1cac66fe8169a5b29b6a6/packages/e2e-cypress/src/install.js#L41-L55
 // We use devDependencies instead of peerDependencies because devDependencies are usually the latest version
-// and peerDependencies could contain a string supporting multiple major versions (e.g. "cypress": "^12.2.0 || ^13.1.0")
+// and peerDependencies could contain a string supporting multiple major versions (e.g. "graphql": "^15.0.0 || ^16.0.0")
 const { devDependencies: aeDevDependencies } = require(
   join(__dirname, '..', 'package.json'),
 )
@@ -20,6 +52,14 @@ function getCompatibleDevDependencies(packageNames) {
   }
 
   return devDependencies
+}
+
+let extendPackageJson = {
+  dependencies: getCompatibleDevDependencies([
+    '@apollo/client',
+    '@vue/apollo-composable',
+    'graphql',
+  ]),
 }
 
 /**
@@ -45,15 +85,23 @@ module.exports = function (api) {
     subscriptionsTransport,
   })
 
+  if (api.prompts.gqlTag) {
+    extendPackageJson = __mergeDeep(extendPackageJson, {
+      dependencies: getCompatibleDevDependencies(['graphql-tag']),
+    })
+  }
+
   if (subscriptionsTransport === 'ws') {
-    api.extendPackageJson({
+    extendPackageJson = __mergeDeep(extendPackageJson, {
       dependencies: getCompatibleDevDependencies(['graphql-ws']),
     })
   } else if (subscriptionsTransport === 'sse') {
-    api.extendPackageJson({
+    extendPackageJson = __mergeDeep(extendPackageJson, {
       dependencies: getCompatibleDevDependencies(['graphql-sse']),
     })
   }
+
+  api.extendPackageJson(extendPackageJson)
 
   api.extendJsonFile('.vscode/extensions.json', {
     recommendations: ['apollographql.vscode-apollo'],

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -9,13 +9,6 @@ module.exports = function () {
       default: false,
     },
     {
-      name: 'gqlTag',
-      type: 'confirm',
-      message:
-        'Will you use `gql` template literal tag to define queries? See https://github.com/apollographql/graphql-tag',
-      default: true,
-    },
-    {
       name: 'subscriptions',
       type: 'confirm',
       message: 'Does your app use GraphQL subscriptions?',

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -9,6 +9,13 @@ module.exports = function () {
       default: false,
     },
     {
+      name: 'gqlTag',
+      type: 'confirm',
+      message:
+        'Will you use `gql` template literal tag to define queries? See https://github.com/apollographql/graphql-tag',
+      default: true,
+    },
+    {
       name: 'subscriptions',
       type: 'confirm',
       message: 'Does your app use GraphQL subscriptions?',

--- a/src/templates/no-typescript/src/apollo/index.js
+++ b/src/templates/no-typescript/src/apollo/index.js
@@ -1,5 +1,6 @@
 import { createHttpLink, InMemoryCache } from '@apollo/client/core'<% if (hasSubscriptions) { %>
 import { split } from '@apollo/client/link/core'
+import { Kind, OperationTypeNode } from 'graphql';
 import { getMainDefinition } from '@apollo/client/utilities'<% if (subscriptionsTransport === 'ws') { %>
 import { GraphQLWsLink } from '@apollo/client/link/subscriptions'
 import { createClient } from 'graphql-ws'<% } else if (subscriptionsTransport === 'sse') { %>
@@ -86,8 +87,8 @@ export /* async */ function getClientOptions(
     ({ query }) => {
       const definition = getMainDefinition(query)
       return (
-        definition.kind === 'OperationDefinition' &&
-        definition.operation === 'subscription'
+        definition.kind === Kind.OPERATION_DEFINITION &&
+        definition.operation === OperationTypeNode.SUBSCRIPTION
       )
     },
     subscriptionLink,

--- a/src/templates/typescript/src/apollo/index.ts
+++ b/src/templates/typescript/src/apollo/index.ts
@@ -2,6 +2,7 @@ import type { ApolloClientOptions } from '@apollo/client/core'
 import { createHttpLink, InMemoryCache } from '@apollo/client/core'
 import type { BootFileParams } from '@quasar/app-<%= hasVite ? 'vite' : 'webpack' %>'<% if (hasSubscriptions) { %>
 import { split } from '@apollo/client/link/core'
+import { Kind, OperationTypeNode } from 'graphql';
 import { getMainDefinition } from '@apollo/client/utilities'<% if (subscriptionsTransport === 'ws') { %>
 import { GraphQLWsLink } from '@apollo/client/link/subscriptions'
 import { createClient } from 'graphql-ws'<% } else if (subscriptionsTransport === 'sse') { %>
@@ -90,8 +91,8 @@ export /* async */ function getClientOptions(
     ({ query }) => {
       const definition = getMainDefinition(query)
       return (
-        definition.kind === 'OperationDefinition' &&
-        definition.operation === 'subscription'
+        definition.kind === Kind.OPERATION_DEFINITION &&
+        definition.operation === OperationTypeNode.SUBSCRIPTION
       )
     },
     subscriptionLink,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@apollo/client@^3.8.3":
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.8.3.tgz#7cd23307bbc788a0a9eda51e6a76f32db8282933"
-  integrity sha512-mK86JM6hCpMEBGDgdO9U8ZYS8r9lPjXE1tVGpJMdSFUsIcXpmEfHUAbbFpPtYmxn8Qa7XsYy0dwDaDhpf4UUPw==
+"@apollo/client@^3.8.6":
+  version "3.8.6"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.8.6.tgz#d90f2a9b0147d8fc96c7a867588b5b2165cc4085"
+  integrity sha512-FnHg3vhQP8tQzgBs6oTJCFFIbovelDGYujj6MK7CJneiHf62TJstCIO0Ot4A1h7XrgFEtgl8a/OgajQWqrTuYw==
   dependencies:
     "@graphql-typed-document-node/core" "^3.1.1"
     "@wry/context" "^0.7.3"
@@ -418,13 +418,14 @@
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-2.3.4.tgz#966a6279060eb2d9d1a02ea1a331af071afdcf9e"
   integrity sha512-IfFNbtkbIm36O9KB8QodlwwYvTEsJb4Lll4c2IwB3VHc2gie2mSPtSzL0eYay7X2jd/2WX02FjSGTWR6OPr/zg==
 
-"@vue/apollo-composable@^4.0.0-alpha.12":
-  version "4.0.0-alpha.12"
-  resolved "https://registry.yarnpkg.com/@vue/apollo-composable/-/apollo-composable-4.0.0-alpha.12.tgz#5aab61bf9703a039e95ef60ecb2293e1da80c87f"
-  integrity sha512-BhCHhDgcDPkKOE3ILb7xIGI98dAsX2Ao3TvOjcMlr89IOK3TuD5B9xgPTsFdctTbupWIVdR/n0FDVXjha7g5iA==
+"@vue/apollo-composable@^4.0.0-beta.11":
+  version "4.0.0-beta.11"
+  resolved "https://registry.yarnpkg.com/@vue/apollo-composable/-/apollo-composable-4.0.0-beta.11.tgz#17af7ec824f521e306ea0c12ac3d94e743621903"
+  integrity sha512-ZtztRDrQe2sTn31h+teBfYw81AePfxlBssTaZVk2jOagdZgTfZigR7aJjO98FxwvGnB80ElWHKubvqYwNf8heg==
   dependencies:
-    throttle-debounce "^2.3.0"
-    vue-demi "^0.4.0"
+    throttle-debounce "^5.0.0"
+    ts-essentials "^9.4.0"
+    vue-demi "^0.14.6"
 
 "@vue/compiler-core@3.3.4":
   version "3.3.4"
@@ -1728,13 +1729,6 @@ graphql-sse@^2.3.0:
   resolved "https://registry.yarnpkg.com/graphql-sse/-/graphql-sse-2.3.0.tgz#53cf8a011c3f4c15ee230a5a817a0f036546a098"
   integrity sha512-D+NL4X3q4XCkp+QL3y+BGmQcFoq87ONhrAvADMoivt/Z5NpxH/8PUzE1+4pYMtJXPhPSQQTXxvIMcjWfqdatjA==
 
-graphql-tag@^2.12.4:
-  version "2.12.4"
-  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.4.tgz#d34066688a4f09e72d6f4663c74211e9b4b7c4bf"
-  integrity sha512-VV1U4O+9x99EkNpNmCUV5RZwq6MnK4+pGbRYWG+lA/m3uo7TSqJF81OkcOP148gFP6fzdl7JWYBrwWVTS9jXww==
-  dependencies:
-    tslib "^2.1.0"
-
 graphql-tag@^2.12.6:
   version "2.12.6"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
@@ -1747,10 +1741,10 @@ graphql-ws@^5.14.0:
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.14.0.tgz#766f249f3974fc2c48fae0d1fb20c2c4c79cd591"
   integrity sha512-itrUTQZP/TgswR4GSSYuwWUzrE/w5GhbwM2GX3ic2U7aw33jgEsayfIlvaj7/GcIvZgNMzsPTrE5hqPuFUiE5g==
 
-graphql@^15.5.0:
-  version "15.5.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.0.tgz#39d19494dbe69d1ea719915b578bf920344a69d5"
-  integrity sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==
+graphql@^16.8.1:
+  version "16.8.1"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.8.1.tgz#1930a965bef1170603702acdb68aedd3f3cf6f07"
+  integrity sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==
 
 has-flag@^4.0.0:
   version "4.0.0"
@@ -2850,10 +2844,10 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-throttle-debounce@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.3.0.tgz#fd31865e66502071e411817e241465b3e9c372e2"
-  integrity sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ==
+throttle-debounce@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-5.0.0.tgz#a17a4039e82a2ed38a5e7268e4132d6960d41933"
+  integrity sha512-2iQTSgkkc1Zyk0MeVrt/3BvuOXYPl/R8Z0U2xxo9rjwNciaHDG3R+Lm6dh4EeUci49DanvBnuqI6jshoQQRGEg==
 
 through@^2.3.6:
   version "2.3.8"
@@ -2883,6 +2877,11 @@ ts-api-utils@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.0.3.tgz#f12c1c781d04427313dbac808f453f050e54a331"
   integrity sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==
+
+ts-essentials@^9.4.0:
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-9.4.1.tgz#6a6b6f81c2138008a5eef216e9fa468d8d9e2ab4"
+  integrity sha512-oke0rI2EN9pzHsesdmrOrnqv1eQODmJpd/noJjwj2ZPC3Z4N2wbjrOEqnsEgmvlO2+4fBb0a794DCna2elEVIQ==
 
 ts-invariant@^0.10.3:
   version "0.10.3"
@@ -2985,10 +2984,10 @@ vite@^2.9.13:
   optionalDependencies:
     fsevents "~2.3.2"
 
-vue-demi@^0.4.0:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.4.5.tgz#ea422a4468cb6321a746826a368a770607f87791"
-  integrity sha512-51xf1B6hV2PfjnzYHO/yUForFCRQ49KS8ngQb5T6l1HDEmfghTFtsxtRa5tbx4eqQsH76ll/0gIxuf1gei0ubw==
+vue-demi@^0.14.6:
+  version "0.14.6"
+  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.14.6.tgz#dc706582851dc1cdc17a0054f4fec2eb6df74c92"
+  integrity sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==
 
 vue@^3.3.4:
   version "3.3.4"


### PR DESCRIPTION
I added a note on the README which explains how to adapt to the change
I specified "2.1.0-beta.2" as release from which this feature will be available, but you can also release it as `2.2.0-beta.1` or whichever else you prefer of course

~~While at it, I made `graphql-tag` optional but installed by default, since it's not always needed~~
While at it, I removed `graphql-tag` as it's re-exported by `@apollo/client/core` anyway, and that's the recommended usage

I also had to fix the code which supports subscriptions, as `graphql` v16 needs enums to be used, while v15 accepted plain strings too