### PR TITLE
feat!: automatically detect TS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,14 @@ You'll need to manually register the latter into `quasar.conf.js > boot`.
 
 ### Prompts
 
-You will be prompted if your app has TypeScript support, if you answer yes,
-`*.ts` files will be added instead of `*.js`.
-
-You will also be prompted if you wish to use GraphQL subscriptions, if you
+You will be prompted if you wish to use GraphQL subscriptions, if you
 answer yes, you will be prompted which subscription transport you wish to use. Available options are:
 
 - Web Socket ([graphql-ws](https://github.com/enisdenjo/graphql-ws))
 - SSE (Server-Sent Events) ([graphql-sse](https://github.com/enisdenjo/graphql-sse))
 
-  After selecting the transport, the necessary dependencies will be installed and the initialization code
-  will be scaffolded for you.
+After selecting the transport, the necessary dependencies will be installed and the initialization code
+will be scaffolded for you.
 
 ## Uninstall
 

--- a/src/install.js
+++ b/src/install.js
@@ -25,20 +25,22 @@ function getCompatibleDevDependencies(packageNames) {
 /**
  * @param {import('@quasar/app-vite').InstallAPI} api
  */
-module.exports = function (api) {
+module.exports = async function (api) {
   // Quasar compatibility check.
   api.compatibleWith('quasar', '^2.0.0')
-  if (api.hasVite === true) {
-    api.compatibleWith('@quasar/app-vite', '^1.0.0')
-  } else {
-    api.compatibleWith('@quasar/app-webpack', '^3.3.3')
+  if (api.hasVite) {
+    // PromptsAPI and hasTypescript() are only available from v1.6.0 onwards
+    api.compatibleWith('@quasar/app-vite', '^v1.6.0');
+  } else if (api.hasWebpack) {
+    // PromptsAPI and hasTypescript() are only available from v3.11.0 onwards
+    api.compatibleWith('@quasar/app-webpack', '^3.11.0');
   }
 
   const hasSubscriptions = api.prompts.subscriptions === true
   const subscriptionsTransport = api.prompts.subscriptionsTransport
 
   api.render('./templates/base')
-  const hasTypescript = api.prompts.typescript === true
+  const hasTypescript = api.hasTypescript()
   api.render(`./templates/${hasTypescript ? 'typescript' : 'no-typescript'}`, {
     hasVite: api.hasVite,
     hasSubscriptions,

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -1,13 +1,6 @@
 /* eslint-env node */
 module.exports = function () {
   return [
-    // TODO: Automatically detect TS support: https://github.com/quasarframework/app-extension-apollo/discussions/107#discussioncomment-7033817
-    {
-      name: 'typescript',
-      type: 'confirm',
-      message: 'Does your app have TypeScript support?',
-      default: false,
-    },
     {
       name: 'subscriptions',
       type: 'confirm',


### PR DESCRIPTION
See https://github.com/quasarframework/app-extension-apollo/discussions/107#discussioncomment-7033817

We have to bump the supported version ranges to utilize `api.hasTypescript()`:
- `@quasar/app-vite`: `^1.0.0` -> `^1.6.0`
- `@quasar/app-webpack`: `^3.3.3` -> `^3.11.0`
