### PR TITLE
docs: add v3 beta callout to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # app-extension-apollo
 
+> **v3 is in beta on the `next` branch** — targeting Apollo Client v4, Vue Apollo v5, and Vite 7.
+> Track progress and join the discussion in [issue #178](https://github.com/quasarframework/app-extension-apollo/issues/178).
+> Install the beta with: `quasar ext add @quasar/apollo@next`
+
 ## Introduction
 
 This is the official Quasar app extension for adding GraphQL to your Quasar


### PR DESCRIPTION
## Summary

- Adds a prominent callout at the top of the README noting that v3 (Apollo Client v4, Vue Apollo v5, Vite 7) is in beta on the `next` branch
- Links to issue #178 for progress tracking and discussion
- Shows the `@next` install tag for early adopters