### PR TITLE
docs: fix Vite version in v3 callout (8 not 7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # app-extension-apollo
 
-> **v3 is in beta on the `next` branch** — targeting Apollo Client v4, Vue Apollo v5, and Vite 7.
+> **v3 is in beta on the `next` branch** — targeting Apollo Client v4, Vue Apollo v5, and Vite 8.
 > Track progress and join the discussion in [issue #178](https://github.com/quasarframework/app-extension-apollo/issues/178).
 > Install the beta with: `quasar ext add @quasar/apollo@next`
 


### PR DESCRIPTION
## Summary

- Fixes a typo in the v3 beta callout: Vite 8, not Vite 7.