### PR TITLE
feat: v2.3.0 — add @quasar/app-vite v3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # app-extension-apollo
 
-> **v3 is in beta on the `next` branch** — targeting Apollo Client v4, Vue Apollo v5, and Vite 8.
-> Track progress and join the discussion in [issue #178](https://github.com/quasarframework/app-extension-apollo/issues/178).
-> Install the beta with: `quasar ext add @quasar/apollo@next`
+> **`@quasar/app-vite` v3 (Vite 8) users:** v2.3.0 adds support with no other breaking changes.
+> Reinstall with `quasar ext add @quasar/apollo` to pick it up.
+>
+> **`@quasar/app-webpack` users:** there is no upgrade path from app-webpack to `@quasar/app-vite` v3
+> within this extension. Stay on v2.x and migrate your project to app-vite first.
+>
+> **Apollo Client v4 + Vue Apollo v5 beta** is tracked in
+> [issue #178](https://github.com/quasarframework/app-extension-apollo/issues/178).
+> Install with: `quasar ext add @quasar/apollo@next`
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # app-extension-apollo
 
-> **`@quasar/app-vite` v3 (Vite 8) users:** v2.3.0 adds support with no other breaking changes.
-> Reinstall with `quasar ext add @quasar/apollo` to pick it up.
+> **`@quasar/app-vite` v3 (Vite 8) users:** v2.3.0-beta.1 adds support with no other breaking changes.
+> Install with `quasar ext add @quasar/apollo@beta` to pick it up.
 >
 > **`@quasar/app-webpack` users:** there is no upgrade path from app-webpack to `@quasar/app-vite` v3
 > within this extension. Stay on v2.x and migrate your project to app-vite first.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quasar/quasar-app-extension-apollo",
-  "version": "2.3.0",
+  "version": "2.3.0-beta.1",
   "description": "A Quasar app extension to add GraphQL support using Apollo Client.",
   "keywords": [
     "quasar",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quasar/quasar-app-extension-apollo",
-  "version": "2.2.4",
+  "version": "2.3.0",
   "description": "A Quasar app extension to add GraphQL support using Apollo Client.",
   "keywords": [
     "quasar",

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ module.exports = function (api) {
   api.compatibleWith('quasar', '^2.0.0')
   if (api.hasVite) {
     // PromptsAPI and hasTypescript() are only available from v1.6.0 onwards
-    api.compatibleWith('@quasar/app-vite', '^1.6.0 || ^2.0.0-beta.9');
+    api.compatibleWith('@quasar/app-vite', '^1.6.0 || ^2.0.0-beta.9 || ^3.0.0-beta.1');
   } else if (api.hasWebpack) {
     // PromptsAPI and hasTypescript() are only available from v3.11.0 onwards
     api.compatibleWith('@quasar/app-webpack', '^3.11.0 || ^4.0.0-beta.1');
@@ -16,9 +16,10 @@ module.exports = function (api) {
   api.extendQuasarConf((conf, api) => {
     // Allow overriding the graphql uri using an env variable
     // https://quasar.dev/quasar-cli/handling-process-env#Adding-to-process.env
-    conf.build.env.GRAPHQL_URI = process.env.GRAPHQL_URI || ''
+    const envTarget = conf.build.defineEnv ?? conf.build.env
+    envTarget.GRAPHQL_URI = process.env.GRAPHQL_URI || ''
     if (api.prompts.subscriptions === true) {
-      conf.build.env.GRAPHQL_URI_WS = process.env.GRAPHQL_URI_WS || ''
+      envTarget.GRAPHQL_URI_WS = process.env.GRAPHQL_URI_WS || ''
     }
 
     // `graphql` package does not work with Vite, so apply a workaround

--- a/src/index.js
+++ b/src/index.js
@@ -25,8 +25,9 @@ module.exports = function (api) {
     // `graphql` package does not work with Vite, so apply a workaround
     // See: https://github.com/quasarframework/app-extension-apollo/issues/154
     if (api.hasVite) {
-      conf.build.rawDefine = {
-        ...conf.build.rawDefine,
+      const defineKey = 'define' in conf.build ? 'define' : 'rawDefine'
+      conf.build[defineKey] = {
+        ...conf.build[defineKey],
         'globalThis.process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
       }
     }


### PR DESCRIPTION
## Summary

- Expands `compatibleWith` range to include `@quasar/app-vite ^3.0.0-beta.1` alongside existing v1/v2 and app-webpack support
- Replaces `conf.build.env` with `conf.build.defineEnv ?? conf.build.env` — app-vite v3 renamed this property; the fallback keeps v1/v2/webpack working unchanged

No other dependency changes. Apollo Client, Vue Apollo, templates — all stay at their current v2 versions.

> The extension stays CJS (no `"type": "module"`), which is fine: app-vite v3 loads extensions via dynamic `import()`, which supports CJS modules natively.
